### PR TITLE
fix: patch ws security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10382,9 +10382,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Updates ws to >8.20.0 to fix moderate uninitialized memory disclosure vulnerability (GHSA-58qx-3vcg-4xpx)

## Test plan
- [x] Verify `npm audit` shows 0 vulnerabilities
- [x] Verify build passes