### PR TITLE
Generate pipecat-flows 1.3.0 direct functions with @flows_tool_options

### DIFF
--- a/components/inspector/forms/FunctionItem.tsx
+++ b/components/inspector/forms/FunctionItem.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react";
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -51,17 +52,30 @@ export const FunctionItem = React.forwardRef<HTMLDivElement, FunctionItemProps>(
       func.next_node_id !== undefined && !availableNodeIds.includes(func.next_node_id);
     const [functionName, setFunctionName] = useState(func.name);
     const [nameError, setNameError] = useState<string | null>(null);
+    const [timeoutInput, setTimeoutInput] = useState(func.timeout_secs?.toString() ?? "");
+    const [timeoutError, setTimeoutError] = useState<string | null>(null);
     const nameInputRef = useRef<HTMLInputElement>(null);
     const [isExpanded, setIsExpanded] = useState(isSelected);
     const defaultNextNodeRef = useRef<HTMLElement | null>(null);
     const functionNameId = useId();
     const functionDescriptionId = useId();
     const nextNodeId = useId();
+    const cancelOnInterruptionId = useId();
+    const timeoutSecsId = useId();
 
     useEffect(() => {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setFunctionName(func.name);
     }, [func.name]);
+
+    // Keep the timeout input in sync when the stored value changes externally
+    // (e.g. switching the selected function, undo/redo).
+    useEffect(() => {
+      /* eslint-disable react-hooks/set-state-in-effect */
+      setTimeoutInput(func.timeout_secs?.toString() ?? "");
+      setTimeoutError(null);
+      /* eslint-enable react-hooks/set-state-in-effect */
+    }, [func.timeout_secs]);
 
     const properties = useMemo(() => func.properties ?? {}, [func.properties]);
     const required = func.required ?? [];
@@ -172,6 +186,26 @@ export const FunctionItem = React.forwardRef<HTMLDivElement, FunctionItemProps>(
           onChange({ name: formatted });
         }
       }
+    };
+
+    // Validate the per-tool timeout on every keystroke. Empty clears it (use the
+    // global default); a positive number commits; anything else shows an error
+    // and leaves the stored value untouched (mirrors the function-name field).
+    const handleTimeoutChange = (raw: string) => {
+      setTimeoutInput(raw);
+      const trimmed = raw.trim();
+      if (trimmed === "") {
+        setTimeoutError(null);
+        if (func.timeout_secs !== undefined) onChange({ timeout_secs: undefined });
+        return;
+      }
+      const parsed = Number(trimmed);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        setTimeoutError("Timeout must be a number greater than 0.");
+        return;
+      }
+      setTimeoutError(null);
+      if (func.timeout_secs !== parsed) onChange({ timeout_secs: parsed });
     };
 
     const setSelectedFunctionIndex = useEditorStore((state) => state.setSelectedFunctionIndex);
@@ -302,6 +336,43 @@ export const FunctionItem = React.forwardRef<HTMLDivElement, FunctionItemProps>(
                   ))}
                 </div>
               )}
+            </div>
+
+            {/* Call Options Section (@flows_tool_options) */}
+            <div className="pt-3 border-t border-neutral-200 dark:border-neutral-700">
+              <div className="text-xs font-medium opacity-80 mb-3">Call options</div>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id={cancelOnInterruptionId}
+                  checked={Boolean(func.cancel_on_interruption)}
+                  onCheckedChange={(checked: boolean) =>
+                    onChange({ cancel_on_interruption: checked ? true : undefined })
+                  }
+                  onFocus={handleFocus}
+                />
+                <label
+                  htmlFor={cancelOnInterruptionId}
+                  className="text-xs opacity-60 cursor-pointer"
+                >
+                  Cancel on interruption
+                </label>
+              </div>
+              <div className="space-y-2 mt-3">
+                <label htmlFor={timeoutSecsId} className="text-xs opacity-60">
+                  Timeout (seconds)
+                </label>
+                <Input
+                  id={timeoutSecsId}
+                  type="number"
+                  step="any"
+                  className={`h-8 text-xs ${timeoutError ? "border-red-500" : ""}`}
+                  value={timeoutInput}
+                  onChange={(e) => handleTimeoutChange(e.target.value)}
+                  onFocus={handleFocus}
+                  placeholder="Use global default"
+                />
+                {timeoutError && <div className="mt-1 text-xs text-red-600">{timeoutError}</div>}
+              </div>
             </div>
 
             {/* Next Node Section */}

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -26,15 +26,17 @@ Use JSON if you want to plug the editor into a custom runtime, build your own ge
 
 ### Generated Python
 
-Selecting **Export → Export Python** downloads a ready-to-run scaffold:
+Selecting **Export → Export Python** downloads a ready-to-run scaffold targeting **pipecat-flows 1.3.0+**:
 
-- One `create_<node_id>_node()` function per node
-- `FlowsFunctionSchema` definitions (including Field metadata) and async handler stubs
+- One `create_<node_id>_node()` factory per node
+- [Direct functions](https://reference-flows.pipecat.ai/en/latest/) — `async def name(flow_manager, ...)` stubs whose schema is derived automatically from the type hints and docstring. JSON-Schema constraints (enum / minimum / maximum / pattern) are folded into the docstring `Args:` section.
+- Result types as plain `TypedDict`s (the deprecated `FlowResult` is no longer used)
+- A `@flows_tool_options(...)` decorator when a function sets call options (cancel-on-interruption and/or a per-tool timeout)
 - Decision routing rendered as Python `if / elif / else` blocks
 - Optional context strategy wiring (adds `ContextStrategyConfig` imports only when needed)
 - Placeholder FlowManager setup showing where to plug in your Pipecat pipeline and transport events
 
-Every handler contains TODOs for your business logic and already returns `(FlowResult | None, NodeConfig | None)` in the proper shape.
+Each direct function takes `flow_manager` first, followed by its parameters as typed arguments, and returns `(result, next_node)` — where `result` is any JSON-serializable value (or `None`) and `next_node` is the `NodeConfig` to transition to (or `None`).
 
 ## Using the Generated Python
 
@@ -49,8 +51,8 @@ pip install pipecat pipecat-ai-flows
 3. **Wire it into your Pipecat entrypoint**:
 
 ```python
+from pipecat.transports.base_transport import BaseTransport
 from pipecat_flows import FlowManager
-from pipecat_flows.transport import BaseTransport
 
 from food_ordering_flow import (
     create_initial_node,
@@ -58,7 +60,7 @@ from food_ordering_flow import (
 )
 
 flow_manager = FlowManager(
-    task=task,
+    worker=worker,  # PipelineWorker; `task=` is deprecated
     llm=llm,
     context_aggregator=context_aggregator,
     transport=transport,
@@ -70,17 +72,17 @@ async def on_client_connected(transport: BaseTransport, client):
     await flow_manager.initialize(create_initial_node())
 ```
 
-4. **Implement the handlers** generated in the file. Each handler already receives `(args, flow_manager)` so you can:
-   - Read user input or prior outputs from `args`
+4. **Implement the direct functions** generated in the file. Each receives `flow_manager` plus its typed parameters, so you can:
+   - Read the user-provided arguments directly as named parameters
    - Store intermediate data in `flow_manager.state`
-   - Decide what node to visit next (or rely on decisions/`next_node_id`)
+   - Decide what node to visit next by returning its `NodeConfig` (or rely on decisions/`next_node_id`)
 
 ### Decision Handling
 
 If a function in the editor contains a decision:
 
-- The generated handler includes the `action` block (your expression, evaluated server-side).
-- Conditions become `if/elif` checks that route to `create_<node_id>_node()` functions.
+- The generated direct function includes the `action` block (your expression, evaluated server-side) and returns `Any` as the result.
+- Conditions become `if/elif/else` checks that route to `create_<node_id>_node()` functions.
 - The editor also stores optional `decision_node_position` so re-importing Python-exported JSON maintains the layout of helper decision nodes in the UI.
 
 ## Using JSON Directly
@@ -90,11 +92,11 @@ If you prefer to consume the JSON yourself:
 | JSON Field                               | Pipecat Usage                                        |
 | ---------------------------------------- | ---------------------------------------------------- |
 | `node.id`                                | `NodeConfig.name`                                    |
-| `node.data.role_messages`                | `NodeConfig.role_messages`                           |
+| `node.data.role_messages`                | `NodeConfig.role_message` (collapsed to a string)    |
 | `node.data.task_messages`                | `NodeConfig.task_messages`                           |
-| `node.data.functions[]`                  | `FlowsFunctionSchema` definitions                    |
+| `node.data.functions[]`                  | Direct functions (auto-derived schema)               |
 | `node.data.functions[].next_node_id`     | Return value `(…, create_<id>_node())`               |
-| `node.data.functions[].decision`         | Custom logic that maps to handler code               |
+| `node.data.functions[].decision`         | Direct function body with `if/elif/else` routing     |
 | `node.data.pre_actions` / `post_actions` | Passed directly into `NodeConfig`                    |
 | `node.data.context_strategy`             | Adds `ContextStrategyConfig`                         |
 | `global_functions`                       | Optional functions registered on every node          |

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -57,7 +57,7 @@ type CommonNodeData = {
 - `label` – Display name used in the canvas/palette
 - `role_messages` – Pipecat role messages (`role` = `system` | `developer` | `user` | `assistant`, `content` = string)
 - `task_messages` – Step-specific instructions
-- `functions` – Available `FlowsFunctionSchema` entries for this node
+- `functions` – Functions available at this node (generated as pipecat-flows direct functions)
 - `pre_actions` / `post_actions` – Pipecat actions executed before/after the node
 - `context_strategy` – Controls Pipecat context accumulation (`APPEND`, `RESET`, `RESET_WITH_SUMMARY` (deprecated))
 - `respond_immediately` – Set to `false` if the node should wait before responding
@@ -72,10 +72,12 @@ type FlowFunction = {
   required?: string[];
   next_node_id?: string;
   decision?: Decision;
+  cancel_on_interruption?: boolean; // @flows_tool_options: cancel the call when the user interrupts
+  timeout_secs?: number; // @flows_tool_options: per-tool timeout override (seconds)
 };
 ```
 
-`properties` and `required` follow JSON Schema semantics and become the arguments that Pipecat hands to the function handler.
+`properties` and `required` follow JSON Schema semantics and become the arguments that Pipecat hands to the function. `cancel_on_interruption` and `timeout_secs` are emitted as a `@flows_tool_options(...)` decorator; both are omitted from the generated decorator when left at their defaults.
 
 #### FunctionProperty
 
@@ -145,7 +147,7 @@ type GlobalFunction = {
 };
 ```
 
-They become `FlowsFunctionSchema` instances registered on the `FlowManager` itself (available to every node).
+They are generated as direct functions and registered on the `FlowManager` itself via `global_functions` (available to every node).
 
 ## Edges
 

--- a/lib/codegen/pythonGenerator.ts
+++ b/lib/codegen/pythonGenerator.ts
@@ -2,11 +2,49 @@ import type {
   FlowFunctionJson,
   FlowJson,
   FlowNodeJson,
+  GlobalFunctionJson,
   MessageJson,
 } from "@/lib/schema/flow.schema";
 
+const INDENT = "    ";
+
+type AnyFunction = FlowFunctionJson | GlobalFunctionJson;
+
 function escapePythonString(str: string): string {
   return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+// Escape triple-quote sequences so user-provided text can't prematurely close a
+// """...""" docstring.
+function escapeTripleQuotes(str: string): string {
+  return str.replace(/"""/g, '\\"\\"\\"');
+}
+
+// Render a string as a Python literal: triple-quoted when it spans multiple
+// lines, otherwise a regular double-quoted string.
+function pythonStringLiteral(content: string): string {
+  if (content.includes("\n")) {
+    return `"""${content.replace(/"""/g, '\\"\\"\\"')}"""`;
+  }
+  return JSON.stringify(content);
+}
+
+// Map a JSON-Schema property type to a Python type hint.
+function pyType(type: string | undefined): string {
+  switch (type) {
+    case "integer":
+      return "int";
+    case "number":
+      return "float";
+    case "boolean":
+      return "bool";
+    case "array":
+      return "list";
+    case "object":
+      return "dict";
+    default:
+      return "str";
+  }
 }
 
 function generateTypeName(funcName: string): string {
@@ -19,210 +57,198 @@ function generateTypeName(funcName: string): string {
   );
 }
 
-function generateTypeDefinition(func: FlowFunctionJson): string {
+function hasProperties(func: AnyFunction): boolean {
+  return Object.keys(func.properties || {}).length > 0;
+}
+
+// Result types are emitted as plain TypedDicts. `FlowResult` is deprecated in
+// pipecat-flows 1.x: handlers may return any JSON-serializable value.
+function generateTypeDefinition(func: AnyFunction): string {
   const typeName = generateTypeName(func.name);
   const props = func.properties || {};
 
-  if (Object.keys(props).length === 0) {
-    // No properties, use base FlowResult
-    return "";
-  }
+  const fields = Object.entries(props).map(([key, prop]) => `    ${key}: ${pyType(prop.type)}`);
 
-  const fields = Object.entries(props).map(([key, prop]) => {
-    const pyType =
-      prop.type === "integer"
-        ? "int"
-        : prop.type === "number"
-          ? "float"
-          : prop.type === "boolean"
-            ? "bool"
-            : "str";
-    const optional = func.required?.includes(key) ? "" : " | None";
-    return `    ${key}: ${pyType}${optional}`;
-  });
-
-  return `class ${typeName}(FlowResult):
-    """Result type for ${func.name} function"""
-${fields.join("\n")}
-`;
+  return `class ${typeName}(TypedDict):
+    """Result type for the ${func.name} function."""
+${fields.join("\n")}`;
 }
 
 function formatMessage(msg: MessageJson): string {
-  // Use triple quotes for multiline content, regular quotes for single line
-  const contentLines = msg.content.split("\n");
-  const hasNewlines = contentLines.length > 1;
-  const contentStr = hasNewlines
-    ? `"""${msg.content.replace(/"""/g, '\\"\\"\\"')}"""`
-    : JSON.stringify(msg.content);
-  return `            {\n                "role": "${msg.role}",\n                "content": ${contentStr}\n            }`;
+  const contentStr = pythonStringLiteral(msg.content);
+  return `            {\n                "role": "${msg.role}",\n                "content": ${contentStr},\n            }`;
 }
 
-function formatProperty(prop: any, indent: string = "            "): string {
+// Build the docstring `Args:` description for a single parameter, folding any
+// JSON-Schema constraints (enum/min/max/pattern) into prose. Direct functions
+// derive their schema from type hints + docstring, so constraints have no other
+// place to live.
+function buildArgDescription(prop: {
+  description?: string;
+  enum?: (string | number)[];
+  minimum?: number;
+  maximum?: number;
+  pattern?: string;
+}): string {
   const parts: string[] = [];
-  if (prop.type) parts.push(`"type": "${prop.type}"`);
-  if (prop.description) parts.push(`"description": "${escapePythonString(prop.description)}"`);
-  if (prop.enum) parts.push(`"enum": ${JSON.stringify(prop.enum)}`);
-  if (prop.minimum !== undefined) parts.push(`"minimum": ${prop.minimum}`);
-  if (prop.maximum !== undefined) parts.push(`"maximum": ${prop.maximum}`);
-  if (prop.pattern) parts.push(`"pattern": "${escapePythonString(prop.pattern)}"`);
-  return `{\n${indent}    ${parts.join(`,\n${indent}    `)}\n${indent}}`;
+  if (prop.description) {
+    let d = prop.description.trim();
+    if (d && !/[.!?]$/.test(d)) d += ".";
+    parts.push(d);
+  }
+  if (prop.enum && prop.enum.length > 0) {
+    const values = prop.enum.map((v) => (typeof v === "string" ? `"${v}"` : v)).join(", ");
+    parts.push(`Allowed values: ${values}.`);
+  }
+  if (prop.minimum !== undefined) parts.push(`Minimum: ${prop.minimum}.`);
+  if (prop.maximum !== undefined) parts.push(`Maximum: ${prop.maximum}.`);
+  if (prop.pattern) parts.push(`Must match the pattern: ${prop.pattern}.`);
+  return parts.join(" ").trim() || "...";
 }
 
-function generateFunction(func: FlowFunctionJson): {
-  handler: string;
-  schema: string;
-  typeDef?: string;
-} {
-  const funcName = func.name;
-  const handlerName = `handle_${funcName}`;
+// Build the full docstring block (already indented one level into the function
+// body). The summary becomes the tool description; the `Args:` section
+// describes each parameter for the LLM.
+function buildDocstring(func: AnyFunction): string {
+  const raw = (func.description || "").trim() || `Handle the ${func.name} function.`;
+  const description = escapeTripleQuotes(raw);
   const props = func.properties || {};
-  const required = func.required || [];
-  const typeName = generateTypeName(funcName);
-  const hasType = Object.keys(props).length > 0;
+  const keys = Object.keys(props);
 
-  // FlowsFunctionSchema requires properties and required to always be set
-  let propertiesBlock = "";
-  if (Object.keys(props).length > 0) {
-    const propLines = Object.entries(props).map(([key, prop]) => {
-      return `            "${key}": ${formatProperty(prop, "            ")}`;
-    });
-    propertiesBlock = `,\n        properties={\n${propLines.join(",\n")}\n        }`;
-  } else {
-    propertiesBlock = ",\n        properties={}";
+  if (keys.length === 0) {
+    if (description.includes("\n")) {
+      const body = description
+        .split("\n")
+        .map((line) => `${INDENT}${line}`)
+        .join("\n");
+      return `${INDENT}"""\n${body}\n${INDENT}"""`;
+    }
+    return `${INDENT}"""${description}"""`;
   }
 
-  const requiredBlock = `,\n        required=${JSON.stringify(required)}`;
+  const descBody = description
+    .split("\n")
+    .map((line) => `${INDENT}${line}`)
+    .join("\n");
+  const argLines = keys
+    .map(
+      (key) =>
+        `${INDENT}${INDENT}${key} (${pyType(props[key].type)}): ${escapeTripleQuotes(
+          buildArgDescription(props[key])
+        )}`
+    )
+    .join("\n");
 
-  // Generate schema code (used for both decision and non-decision functions)
-  const schemaCode = `    ${funcName}_func = FlowsFunctionSchema(
-        name="${funcName}",
-        handler=handle_${funcName},
-        description="${escapePythonString(func.description)}"${propertiesBlock}${requiredBlock}
-    )`;
+  return `${INDENT}"""\n${descBody}\n\n${INDENT}Args:\n${argLines}\n${INDENT}"""`;
+}
 
-  // Generate type definition (used for both decision and non-decision functions)
-  const typeDefCode = hasType ? generateTypeDefinition(func) : undefined;
+// Build the typed parameter list that follows `flow_manager` in a direct
+// function signature, e.g. ", size: int, party_size: int".
+function buildParams(func: AnyFunction): string {
+  const props = func.properties || {};
+  return Object.entries(props)
+    .map(([key, prop]) => `, ${key}: ${pyType(prop.type)}`)
+    .join("");
+}
 
-  // Generate typed argument extraction
-  const argExtraction =
-    Object.keys(props).length > 0
-      ? Object.entries(props)
-          .map(([key, prop]) => {
-            const pyType =
-              prop.type === "integer"
-                ? "int"
-                : prop.type === "number"
-                  ? "float"
-                  : prop.type === "boolean"
-                    ? "bool"
-                    : "str";
-            const defaultValue =
-              prop.type === "integer" || prop.type === "number"
-                ? "0"
-                : prop.type === "boolean"
-                  ? "False"
-                  : '""';
-            return `        ${key}: ${pyType} = args.get("${key}", ${defaultValue})`;
-          })
-          .join("\n") + "\n"
-      : "";
+// True when a function overrides any @flows_tool_options default.
+function usesToolOptions(func: AnyFunction): boolean {
+  return Boolean(func.cancel_on_interruption) || func.timeout_secs != null;
+}
 
-  let nextNodeRouting: string;
-  let decisionCode = "";
+// Build the optional `@flows_tool_options(...)` decorator line (with a trailing
+// newline), or an empty string when the call options are left at their defaults.
+function buildToolOptionsDecorator(func: AnyFunction): string {
+  if (!usesToolOptions(func)) return "";
+  const opts: string[] = [];
+  if (func.cancel_on_interruption) opts.push("cancel_on_interruption=True");
+  if (func.timeout_secs != null) opts.push(`timeout_secs=${func.timeout_secs}`);
+  return `@flows_tool_options(${opts.join(", ")})\n`;
+}
 
-  // Handle decision logic
+// Generate a single direct function. Works for both node functions (which may
+// route to a next node or branch via a decision) and global functions (no
+// routing). The schema is extracted automatically by pipecat-flows from the
+// signature and docstring below.
+function generateDirectFunction(func: FlowFunctionJson): string {
+  const funcName = func.name;
+  const hasType = hasProperties(func);
+  const typeName = generateTypeName(funcName);
+  const params = buildParams(func);
+  const docstring = buildDocstring(func);
+  const decorator = buildToolOptionsDecorator(func);
+
+  // Decision functions: run the action block, then branch to a next node.
   if (func.decision) {
-    // Execute action code block (user must set result variable)
-    decisionCode = `        # Execute action (must set 'result' variable)\n${func.decision.action
+    let body = `${INDENT}# Execute action (must set the 'result' variable)\n${func.decision.action
       .split("\n")
-      .map((line) => `        ${line}`)
+      .map((line) => `${INDENT}${line}`)
       .join("\n")}\n\n`;
 
-    // Generate if/elif/else chain if there are conditions
     if (func.decision.conditions.length > 0) {
-      decisionCode += "        # Conditional routing\n";
+      body += `${INDENT}# Conditional routing\n`;
       func.decision.conditions.forEach((condition, index) => {
-        const indent = index === 0 ? "if" : "elif";
-        // Handle special operators like "not", "in", "not in"
+        const keyword = index === 0 ? "if" : "elif";
         let conditionExpr: string;
         if (condition.operator === "not") {
-          conditionExpr = `not result`;
+          conditionExpr = "not result";
         } else if (condition.operator === "in") {
           conditionExpr = `result in ${condition.value}`;
         } else if (condition.operator === "not in") {
           conditionExpr = `result not in ${condition.value}`;
         } else {
-          // For comparison operators, try to parse value as appropriate type
-          // For now, keep as string comparison - user can wrap in quotes if needed
           conditionExpr = `result ${condition.operator} ${condition.value}`;
         }
-        decisionCode += `        ${indent} ${conditionExpr}:\n            return result, create_${condition.next_node_id}_node()\n`;
+        body += `${INDENT}${keyword} ${conditionExpr}:\n${INDENT}${INDENT}return result, create_${condition.next_node_id}_node()\n`;
       });
-      decisionCode += `        else:\n            return result, create_${func.decision.default_next_node_id}_node()\n`;
+      body += `${INDENT}else:\n${INDENT}${INDENT}return result, create_${func.decision.default_next_node_id}_node()`;
     } else {
-      // No conditions, just return default
-      decisionCode += `        return result, create_${func.decision.default_next_node_id}_node()\n`;
+      body += `${INDENT}return result, create_${func.decision.default_next_node_id}_node()`;
     }
 
-    // Return type for decision: result is Any (action result)
-    const returnTypeAnnotation = `tuple[Any, NodeConfig]`;
-
-    const handlerCode = `
-    async def ${handlerName}(args: FlowArgs, flow_manager: FlowManager) -> ${returnTypeAnnotation}:
-        """Handler for ${funcName} function"""
-${argExtraction}${decisionCode}
-`;
-
-    return {
-      handler: handlerCode,
-      schema: schemaCode,
-      typeDef: typeDefCode,
-    };
+    return `${decorator}async def ${funcName}(flow_manager: FlowManager${params}) -> tuple[Any, NodeConfig]:
+${docstring}
+${body}`;
   }
 
-  // Original logic for non-decision functions
-  if (!hasType) {
-    // No properties, return None
-    if (func.next_node_id) {
-      nextNodeRouting = `        return None, create_${func.next_node_id}_node()`;
-    } else {
-      nextNodeRouting = "        return None, None";
-    }
-  } else {
-    // Has properties, use named parameters
-    const namedParams = Object.keys(props)
+  // Plain functions: optionally produce a result and route to a next node.
+  const resultType = hasType ? typeName : "None";
+  const nextType = func.next_node_id ? "NodeConfig" : "None";
+
+  let resultValue: string;
+  if (hasType) {
+    const namedParams = Object.keys(func.properties || {})
       .map((key) => `${key}=${key}`)
       .join(", ");
-    if (func.next_node_id) {
-      nextNodeRouting = `        return ${typeName}(${namedParams}), create_${func.next_node_id}_node()`;
-    } else {
-      nextNodeRouting = `        return ${typeName}(${namedParams}), None`;
-    }
+    resultValue = `${typeName}(${namedParams})`;
+  } else {
+    resultValue = "None";
   }
+  const nextValue = func.next_node_id ? `create_${func.next_node_id}_node()` : "None";
 
-  // Generate return type annotation
-  // If no type, return type is just None (not None | None)
-  const firstType = hasType ? `${typeName} | None` : "None";
-  const returnTypeAnnotation = func.next_node_id
-    ? `tuple[${firstType}, NodeConfig]`
-    : `tuple[${firstType}, NodeConfig | None]`;
-
-  const handlerCode = `
-    async def ${handlerName}(args: FlowArgs, flow_manager: FlowManager) -> ${returnTypeAnnotation}:
-        """Handler for ${funcName} function"""
-${argExtraction}        # TODO: Implement function logic
-        # Update flow_manager.state as needed
-${nextNodeRouting}
-`;
-
-  return {
-    handler: handlerCode,
-    schema: schemaCode,
-    typeDef: typeDefCode,
-  };
+  return `${decorator}async def ${funcName}(flow_manager: FlowManager${params}) -> tuple[${resultType}, ${nextType}]:
+${docstring}
+${INDENT}# TODO: Implement function logic
+${INDENT}# Update flow_manager.state as needed
+${INDENT}return ${resultValue}, ${nextValue}`;
 }
 
-function generateNodeFunction(node: FlowNodeJson): { nodeCode: string; typeDefs: string[] } {
+function formatActions(actions: { type: string; handler?: string; text?: string }[]): string {
+  const actionStrs = actions.map((action) => {
+    if (action.type === "end_conversation") {
+      return `            {"type": "end_conversation"}`;
+    } else if (action.type === "function" && action.handler) {
+      return `            {"type": "function", "handler": ${action.handler}}`;
+    } else if (action.type === "tts_say" && action.text) {
+      return `            {"type": "tts_say", "text": "${escapePythonString(action.text)}"}`;
+    }
+    return `            {"type": "${action.type}"}`;
+  });
+  return actionStrs.join(",\n");
+}
+
+// Generate the create_<id>_node() factory for a single node.
+function generateNodeFactory(node: FlowNodeJson): string {
   const nodeId = node.id;
   const data = node.data || {};
 
@@ -232,41 +258,20 @@ function generateNodeFunction(node: FlowNodeJson): { nodeCode: string; typeDefs:
   const preActions = data.pre_actions || [];
   const postActions = data.post_actions || [];
   const contextStrategy = data.context_strategy as
-    | { strategy: "APPEND" | "RESET" | "RESET_WITH_SUMMARY"; summary_prompt?: string } // RESET_WITH_SUMMARY deprecated in 1.0
+    | { strategy: "APPEND" | "RESET" | "RESET_WITH_SUMMARY"; summary_prompt?: string }
     | undefined;
 
   let code = `def create_${nodeId}_node() -> NodeConfig:
     """Create the ${data.label || nodeId} node."""
+    return NodeConfig(
+        name="${nodeId}",
 `;
 
-  // Generate function handlers and collect type definitions
-  const functionHandlers: string[] = [];
-  const functionSchemas: string[] = [];
-  const functionRefs: string[] = [];
-  const typeDefs: string[] = [];
-
-  functions.forEach((func) => {
-    const funcGen = generateFunction(func);
-    if (funcGen.typeDef) {
-      typeDefs.push(funcGen.typeDef);
-    }
-    functionHandlers.push(funcGen.handler);
-    functionSchemas.push(funcGen.schema);
-    functionRefs.push(`${func.name}_func`);
-  });
-
-  if (functionHandlers.length > 0) {
-    code += functionHandlers.join("\n");
-    code += "\n";
-    code += functionSchemas.join("\n");
-    code += "\n";
-  }
-
-  code += `    return NodeConfig(
-        name="${nodeId}",\n`;
-
+  // `role_message` (str) replaces the deprecated `role_messages` (list). Collapse
+  // any role messages into a single system instruction string.
   if (roleMessages.length > 0) {
-    code += `        role_messages=[\n${roleMessages.map(formatMessage).join(",\n")}\n        ],\n`;
+    const roleContent = roleMessages.map((m) => m.content).join("\n\n");
+    code += `        role_message=${pythonStringLiteral(roleContent)},\n`;
   }
 
   if (taskMessages.length > 0) {
@@ -274,35 +279,15 @@ function generateNodeFunction(node: FlowNodeJson): { nodeCode: string; typeDefs:
   }
 
   if (functions.length > 0) {
-    code += `        functions=[${functionRefs.join(", ")}],\n`;
+    code += `        functions=[${functions.map((f) => f.name).join(", ")}],\n`;
   }
 
   if (preActions.length > 0) {
-    const actionStrs = preActions.map((action) => {
-      if (action.type === "end_conversation") {
-        return `            {"type": "end_conversation"}`;
-      } else if (action.type === "function" && action.handler) {
-        return `            {"type": "function", "handler": ${action.handler}}`;
-      } else if (action.type === "tts_say" && action.text) {
-        return `            {"type": "tts_say", "text": "${escapePythonString(action.text)}"}`;
-      }
-      return `            {"type": "${action.type}"}`;
-    });
-    code += `        pre_actions=[\n${actionStrs.join(",\n")}\n        ],\n`;
+    code += `        pre_actions=[\n${formatActions(preActions)}\n        ],\n`;
   }
 
   if (postActions.length > 0) {
-    const actionStrs = postActions.map((action) => {
-      if (action.type === "end_conversation") {
-        return `            {"type": "end_conversation"}`;
-      } else if (action.type === "function" && action.handler) {
-        return `            {"type": "function", "handler": ${action.handler}}`;
-      } else if (action.type === "tts_say" && action.text) {
-        return `            {"type": "tts_say", "text": "${escapePythonString(action.text)}"}`;
-      }
-      return `            {"type": "${action.type}"}`;
-    });
-    code += `        post_actions=[\n${actionStrs.join(",\n")}\n        ],\n`;
+    code += `        post_actions=[\n${formatActions(postActions)}\n        ],\n`;
   }
 
   if (contextStrategy && contextStrategy.strategy !== "APPEND") {
@@ -310,182 +295,135 @@ function generateNodeFunction(node: FlowNodeJson): { nodeCode: string; typeDefs:
       const summaryPrompt = contextStrategy.summary_prompt
         ? escapePythonString(contextStrategy.summary_prompt)
         : "";
-      code += `        context_strategy=ContextStrategyConfig(\n            strategy=ContextStrategy.${contextStrategy.strategy},\n            summary_prompt="${summaryPrompt}"\n        ),\n`;
+      code += `        context_strategy=ContextStrategyConfig(\n            strategy=ContextStrategy.${contextStrategy.strategy},\n            summary_prompt="${summaryPrompt}",\n        ),\n`;
     } else {
       code += `        context_strategy=ContextStrategyConfig(\n            strategy=ContextStrategy.${contextStrategy.strategy}\n        ),\n`;
     }
   }
 
-  // Only include respond_immediately if it's False (True is the default)
-  const respondImmediately = data.respond_immediately !== false;
-  if (!respondImmediately) {
+  // respond_immediately defaults to True; only emit it when False.
+  if (data.respond_immediately === false) {
     code += `        respond_immediately=False,\n`;
   }
 
   code += `    )`;
 
-  return { nodeCode: code, typeDefs };
-}
-
-function generateGlobalFunctions(flow: FlowJson): string {
-  const globalFuncs = flow.global_functions || [];
-  if (globalFuncs.length === 0) return "";
-
-  let code = "\n# Global functions\n";
-  globalFuncs.forEach((func) => {
-    const props = func.properties || {};
-    const required = func.required || [];
-    const hasType = Object.keys(props).length > 0;
-    const typeName = hasType ? generateTypeName(func.name) : "FlowResult";
-    const handlerName = `handle_${func.name}`;
-
-    // FlowsFunctionSchema requires properties and required to always be set
-    let propertiesBlock = "";
-    if (Object.keys(props).length > 0) {
-      const propLines = Object.entries(props).map(([key, prop]) => {
-        return `            "${key}": ${formatProperty(prop, "            ")}`;
-      });
-      propertiesBlock = `,\n        properties={\n${propLines.join(",\n")}\n        }`;
-    } else {
-      propertiesBlock = ",\n        properties={}";
-    }
-
-    const requiredBlock = `,\n        required=${JSON.stringify(required)}`;
-
-    const argExtraction =
-      Object.keys(props).length > 0
-        ? Object.entries(props)
-            .map(([key, prop]) => {
-              const pyType =
-                prop.type === "integer"
-                  ? "int"
-                  : prop.type === "number"
-                    ? "float"
-                    : prop.type === "boolean"
-                      ? "bool"
-                      : "str";
-              const defaultValue =
-                prop.type === "integer" || prop.type === "number"
-                  ? "0"
-                  : prop.type === "boolean"
-                    ? "False"
-                    : '""';
-              return `        ${key}: ${pyType} = args.get("${key}", ${defaultValue})`;
-            })
-            .join("\n") + "\n"
-        : "";
-
-    // Generate result creation with named parameters
-    let resultReturn: string;
-    let returnTypeAnnotation: string;
-    if (!hasType) {
-      resultReturn = "        return None, None";
-      returnTypeAnnotation = "tuple[None, None]";
-    } else {
-      const namedParams = Object.keys(props)
-        .map((key) => `${key}=${key}`)
-        .join(", ");
-      resultReturn = `        return ${typeName}(${namedParams}), None`;
-      // For functions with types, return type can be the type or None
-      returnTypeAnnotation = `tuple[${typeName} | None, None]`;
-    }
-
-    code += `async def ${handlerName}(args: FlowArgs, flow_manager: FlowManager) -> ${returnTypeAnnotation}:
-    """Global function: ${func.name}"""
-${argExtraction}    # TODO: Implement ${func.name}
-${resultReturn}
-
-${func.name}_func = FlowsFunctionSchema(
-    name="${func.name}",
-    handler=${handlerName},
-    description="${escapePythonString(func.description)}"${propertiesBlock}${requiredBlock}
-)
-
-`;
-  });
-
   return code;
 }
 
 export function generatePythonCode(flow: FlowJson): string {
-  // Check if any node uses context_strategy
-  const hasContextStrategy = flow.nodes.some(
+  const nodes = flow.nodes || [];
+  const globalFuncs = flow.global_functions || [];
+  const initialNode = nodes.find((n) => n.type === "initial");
+  const initialNodeId = initialNode?.id || nodes[0]?.id || "initial";
+
+  // Determine which optional imports are needed.
+  const hasContextStrategy = nodes.some(
     (node) => node.data?.context_strategy && node.data.context_strategy.strategy !== "APPEND"
   );
+  const allNodeFunctions = nodes.flatMap(
+    (node) => (node.data?.functions as FlowFunctionJson[] | undefined) || []
+  );
+  const hasDecision = allNodeFunctions.some((func) => func.decision !== undefined);
 
-  // Check if any function has a decision (needs Any type)
-  const hasDecision = flow.nodes.some((node) => {
-    const functions = (node.data?.functions as FlowFunctionJson[] | undefined) || [];
-    return functions.some((func) => func.decision !== undefined);
-  });
-
-  const nodes = flow.nodes || [];
-  const initialNode = nodes.find((n) => n.type === "initial");
-  const globalFuncs = flow.global_functions || [];
-
-  // Collect all type definitions first
-  const allTypeDefs = new Set<string>();
-  const nodeFunctions: { nodeCode: string; typeDefs: string[] }[] = [];
-
-  nodes.forEach((node) => {
-    const funcGen = generateNodeFunction(node);
-    funcGen.typeDefs.forEach((td) => allTypeDefs.add(td));
-    nodeFunctions.push(funcGen);
-  });
-
-  // Generate global function types
-  globalFuncs.forEach((func) => {
-    const props = func.properties || {};
-    if (Object.keys(props).length > 0) {
-      allTypeDefs.add(generateTypeDefinition(func));
+  // Collect result TypedDefs, de-duplicated by type name (first occurrence wins,
+  // matching the function-body dedup below; globals come first). Decision
+  // functions return `Any` (the action's `result`), so they get no result type.
+  const typeDefs = new Map<string, string>();
+  for (const func of [...globalFuncs, ...allNodeFunctions]) {
+    const isDecision = "decision" in func && Boolean(func.decision);
+    const typeName = generateTypeName(func.name);
+    if (hasProperties(func) && !isDecision && !typeDefs.has(typeName)) {
+      typeDefs.set(typeName, generateTypeDefinition(func));
     }
-  });
+  }
 
-  const initialNodeId = initialNode?.id || "initial";
-  const globalFuncRefs =
-    globalFuncs.length > 0 ? globalFuncs.map((f) => `${f.name}_func`).join(", ") : "";
+  // Imports
+  const typingImports = [hasDecision ? "Any" : null, typeDefs.size > 0 ? "TypedDict" : null].filter(
+    Boolean
+  );
+  const flowsImports = ["FlowManager", "NodeConfig"];
+  if (hasContextStrategy) {
+    flowsImports.push("ContextStrategy", "ContextStrategyConfig");
+  }
+  if ([...globalFuncs, ...allNodeFunctions].some(usesToolOptions)) {
+    flowsImports.push("flows_tool_options");
+  }
 
-  let code = `"""Generated Pipecat Flow: ${flow.meta.name}
+  // Each entry below is a top-level block; blocks are joined with two blank
+  // lines (PEP 8) when assembled at the end.
+  const blocks: string[] = [];
+
+  const moduleDocstring = `"""Generated Pipecat Flow: ${flow.meta.name}
 
 This file was generated from the visual flow editor.
-Customize the function handlers to implement your flow logic.
-"""
 
-${hasDecision ? "from typing import Any\n\n" : ""}from pipecat_flows import (
-    FlowArgs,
-    FlowManager,
-    FlowResult,
-    FlowsFunctionSchema,
-    NodeConfig${hasContextStrategy ? ",\n    ContextStrategy,\n    ContextStrategyConfig" : ""},
-)
+Functions are defined as pipecat-flows "direct functions": their schemas are
+extracted automatically from each function's signature and docstring. Fill in
+the function bodies to implement your flow logic.
+"""`;
+  blocks.push(moduleDocstring);
 
-# Type definitions
-${Array.from(allTypeDefs).join("\n")}
+  let importBlock = "";
+  if (typingImports.length > 0) {
+    importBlock += `from typing import ${typingImports.join(", ")}\n\n`;
+  }
+  importBlock += `from pipecat_flows import (\n${flowsImports.map((i) => `    ${i},`).join("\n")}\n)`;
+  blocks.push(importBlock);
 
-${generateGlobalFunctions(flow)}
+  // Result type definitions
+  if (typeDefs.size > 0) {
+    blocks.push(`# Type definitions\n${Array.from(typeDefs.values()).join("\n\n\n")}`);
+  }
 
-# Node creation functions
-`;
+  // Global functions (direct functions registered on every node).
+  if (globalFuncs.length > 0) {
+    const globals = globalFuncs
+      .map((func) => generateDirectFunction(func as FlowFunctionJson))
+      .join("\n\n\n");
+    blocks.push(`# Global functions (available at every node)\n${globals}`);
+  }
 
-  // Generate all node functions
-  nodeFunctions.forEach((funcGen) => {
-    code += funcGen.nodeCode;
-    code += "\n\n";
-  });
+  // Node functions (direct functions), grouped per node and de-duplicated by
+  // name so shared functions are defined only once. Global function names are
+  // seeded so a node function never redefines a global of the same name.
+  const emitted = new Set<string>(globalFuncs.map((f) => f.name));
+  for (const node of nodes) {
+    const functions = (node.data?.functions as FlowFunctionJson[] | undefined) || [];
+    const fresh = functions.filter((func) => !emitted.has(func.name));
+    if (fresh.length === 0) continue;
+    const label = node.data?.label || node.id;
+    const groupFns = fresh
+      .map((func) => {
+        emitted.add(func.name);
+        return generateDirectFunction(func);
+      })
+      .join("\n\n\n");
+    blocks.push(`# Functions for the ${label} node\n${groupFns}`);
+  }
 
-  // Generate FlowManager initialization section (commented)
-  code += `# FlowManager Setup
-# 
-# Initialize the FlowManager in your bot setup:
+  // Node creation functions
+  blocks.push(`# Node creation functions\n${nodes.map(generateNodeFactory).join("\n\n\n")}`);
+
+  // FlowManager setup (commented scaffold).
+  const globalFuncRefs = globalFuncs.map((f) => f.name).join(", ");
+  const globalFuncsLine =
+    globalFuncs.length > 0
+      ? `#         global_functions=[${globalFuncRefs}],`
+      : `#         # global_functions=[...],`;
+
+  blocks.push(`# FlowManager Setup
+#
+# Wire the generated nodes into your Pipecat bot:
 #
 # async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
 #     stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
 #     tts = CartesiaTTSService(api_key=os.getenv("CARTESIA_API_KEY"))
-#     llm = create_llm()  # Your LLM service
-#     
+#     llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"))
+#
 #     context = LLMContext()
 #     context_aggregator = LLMContextAggregatorPair(context)
-#     
+#
 #     pipeline = Pipeline([
 #         transport.input(),
 #         stt,
@@ -495,24 +433,26 @@ ${generateGlobalFunctions(flow)}
 #         transport.output(),
 #         context_aggregator.assistant(),
 #     ])
-#     
-#     task = PipelineTask(pipeline, params=PipelineParams(allow_interruptions=True))
-#     
-#     # Initialize FlowManager
+#
+#     worker = PipelineWorker(pipeline, params=PipelineParams(enable_metrics=True))
+#
+#     # Initialize the FlowManager
 #     flow_manager = FlowManager(
-#         task=task,
+#         worker=worker,
 #         llm=llm,
 #         context_aggregator=context_aggregator,
 #         transport=transport,
-#         # global_functions=[${globalFuncRefs}],
+${globalFuncsLine}
 #     )
-#     
+#
 #     @transport.event_handler("on_client_connected")
 #     async def on_client_connected(transport, client):
-#         logger.info("Client connected")
-#         # Start the flow with the initial node
+#         # Kick off the conversation with the initial node
 #         await flow_manager.initialize(create_${initialNodeId}_node())
-`;
+#
+#     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+#     await runner.add_workers(worker)
+#     await runner.run()`);
 
-  return code;
+  return blocks.join("\n\n\n") + "\n";
 }

--- a/lib/codegen/pythonGenerator.ts
+++ b/lib/codegen/pythonGenerator.ts
@@ -14,17 +14,28 @@ function escapePythonString(str: string): string {
   return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
 }
 
-// Escape triple-quote sequences so user-provided text can't prematurely close a
-// """...""" docstring.
+// Escape user text for safe embedding inside a """...""" string, preserving
+// newlines. Backslashes are escaped first (so sequences like \u can't form an
+// invalid Python escape and a trailing \ can't escape the closing quote); then
+// any """ run is escaped so it can't close the string early. Interior single
+// quotes are left untouched for readability.
 function escapeTripleQuotes(str: string): string {
-  return str.replace(/"""/g, '\\"\\"\\"');
+  return str.replace(/\\/g, "\\\\").replace(/"""/g, '\\"\\"\\"');
+}
+
+// When escaped content sits immediately before a closing """, a trailing " (or
+// "") would merge into """" and break the literal. Escape a trailing quote so
+// the delimiter stays unambiguous. (Not needed when a newline separates the
+// content from the closing delimiter.)
+function guardTrailingQuote(str: string): string {
+  return str.endsWith('"') ? `${str.slice(0, -1)}\\"` : str;
 }
 
 // Render a string as a Python literal: triple-quoted when it spans multiple
 // lines, otherwise a regular double-quoted string.
 function pythonStringLiteral(content: string): string {
   if (content.includes("\n")) {
-    return `"""${content.replace(/"""/g, '\\"\\"\\"')}"""`;
+    return `"""${guardTrailingQuote(escapeTripleQuotes(content))}"""`;
   }
   return JSON.stringify(content);
 }
@@ -61,13 +72,29 @@ function hasProperties(func: AnyFunction): boolean {
   return Object.keys(func.properties || {}).length > 0;
 }
 
+// Order a function's properties with required ones first. This keeps the
+// generated signature valid (parameters with defaults must follow those
+// without) and ensures the signature, docstring, result type, and result value
+// all agree on ordering.
+function orderedKeys(func: AnyFunction): { key: string; required: boolean }[] {
+  const keys = Object.keys(func.properties || {});
+  const required = new Set(func.required || []);
+  return [...keys.filter((k) => required.has(k)), ...keys.filter((k) => !required.has(k))].map(
+    (key) => ({ key, required: required.has(key) })
+  );
+}
+
 // Result types are emitted as plain TypedDicts. `FlowResult` is deprecated in
-// pipecat-flows 1.x: handlers may return any JSON-serializable value.
+// pipecat-flows 1.x: handlers may return any JSON-serializable value. Optional
+// (non-required) inputs are nullable, matching their `| None = None` defaults.
 function generateTypeDefinition(func: AnyFunction): string {
   const typeName = generateTypeName(func.name);
   const props = func.properties || {};
 
-  const fields = Object.entries(props).map(([key, prop]) => `    ${key}: ${pyType(prop.type)}`);
+  const fields = orderedKeys(func).map(({ key, required }) => {
+    const t = pyType(props[key].type);
+    return `    ${key}: ${required ? t : `${t} | None`}`;
+  });
 
   return `class ${typeName}(TypedDict):
     """Result type for the ${func.name} function."""
@@ -130,9 +157,9 @@ function buildDocstring(func: AnyFunction): string {
     .split("\n")
     .map((line) => `${INDENT}${line}`)
     .join("\n");
-  const argLines = keys
+  const argLines = orderedKeys(func)
     .map(
-      (key) =>
+      ({ key }) =>
         `${INDENT}${INDENT}${key} (${pyType(props[key].type)}): ${escapeTripleQuotes(
           buildArgDescription(props[key])
         )}`
@@ -143,11 +170,16 @@ function buildDocstring(func: AnyFunction): string {
 }
 
 // Build the typed parameter list that follows `flow_manager` in a direct
-// function signature, e.g. ", size: int, party_size: int".
+// function signature, e.g. ", size: int, party_size: int". Non-required
+// properties become optional parameters (`name: type | None = None`) so the
+// derived tool schema marks them optional too.
 function buildParams(func: AnyFunction): string {
   const props = func.properties || {};
-  return Object.entries(props)
-    .map(([key, prop]) => `, ${key}: ${pyType(prop.type)}`)
+  return orderedKeys(func)
+    .map(({ key, required }) => {
+      const t = pyType(props[key].type);
+      return required ? `, ${key}: ${t}` : `, ${key}: ${t} | None = None`;
+    })
     .join("");
 }
 
@@ -170,7 +202,7 @@ function buildToolOptionsDecorator(func: AnyFunction): string {
 // route to a next node or branch via a decision) and global functions (no
 // routing). The schema is extracted automatically by pipecat-flows from the
 // signature and docstring below.
-function generateDirectFunction(func: FlowFunctionJson): string {
+function generateDirectFunction(func: AnyFunction): string {
   const funcName = func.name;
   const hasType = hasProperties(func);
   const typeName = generateTypeName(funcName);
@@ -178,16 +210,20 @@ function generateDirectFunction(func: FlowFunctionJson): string {
   const docstring = buildDocstring(func);
   const decorator = buildToolOptionsDecorator(func);
 
+  // Routing fields only exist on node functions; global functions have neither.
+  const decision = "decision" in func ? func.decision : undefined;
+  const nextNodeId = "next_node_id" in func ? func.next_node_id : undefined;
+
   // Decision functions: run the action block, then branch to a next node.
-  if (func.decision) {
-    let body = `${INDENT}# Execute action (must set the 'result' variable)\n${func.decision.action
+  if (decision) {
+    let body = `${INDENT}# Execute action (must set the 'result' variable)\n${decision.action
       .split("\n")
       .map((line) => `${INDENT}${line}`)
       .join("\n")}\n\n`;
 
-    if (func.decision.conditions.length > 0) {
+    if (decision.conditions.length > 0) {
       body += `${INDENT}# Conditional routing\n`;
-      func.decision.conditions.forEach((condition, index) => {
+      decision.conditions.forEach((condition, index) => {
         const keyword = index === 0 ? "if" : "elif";
         let conditionExpr: string;
         if (condition.operator === "not") {
@@ -201,9 +237,9 @@ function generateDirectFunction(func: FlowFunctionJson): string {
         }
         body += `${INDENT}${keyword} ${conditionExpr}:\n${INDENT}${INDENT}return result, create_${condition.next_node_id}_node()\n`;
       });
-      body += `${INDENT}else:\n${INDENT}${INDENT}return result, create_${func.decision.default_next_node_id}_node()`;
+      body += `${INDENT}else:\n${INDENT}${INDENT}return result, create_${decision.default_next_node_id}_node()`;
     } else {
-      body += `${INDENT}return result, create_${func.decision.default_next_node_id}_node()`;
+      body += `${INDENT}return result, create_${decision.default_next_node_id}_node()`;
     }
 
     return `${decorator}async def ${funcName}(flow_manager: FlowManager${params}) -> tuple[Any, NodeConfig]:
@@ -213,18 +249,18 @@ ${body}`;
 
   // Plain functions: optionally produce a result and route to a next node.
   const resultType = hasType ? typeName : "None";
-  const nextType = func.next_node_id ? "NodeConfig" : "None";
+  const nextType = nextNodeId ? "NodeConfig" : "None";
 
   let resultValue: string;
   if (hasType) {
-    const namedParams = Object.keys(func.properties || {})
-      .map((key) => `${key}=${key}`)
+    const namedParams = orderedKeys(func)
+      .map(({ key }) => `${key}=${key}`)
       .join(", ");
     resultValue = `${typeName}(${namedParams})`;
   } else {
     resultValue = "None";
   }
-  const nextValue = func.next_node_id ? `create_${func.next_node_id}_node()` : "None";
+  const nextValue = nextNodeId ? `create_${nextNodeId}_node()` : "None";
 
   return `${decorator}async def ${funcName}(flow_manager: FlowManager${params}) -> tuple[${resultType}, ${nextType}]:
 ${docstring}
@@ -378,9 +414,7 @@ the function bodies to implement your flow logic.
 
   // Global functions (direct functions registered on every node).
   if (globalFuncs.length > 0) {
-    const globals = globalFuncs
-      .map((func) => generateDirectFunction(func as FlowFunctionJson))
-      .join("\n\n\n");
+    const globals = globalFuncs.map((func) => generateDirectFunction(func)).join("\n\n\n");
     blocks.push(`# Global functions (available at every node)\n${globals}`);
   }
 

--- a/lib/schema/flow.schema.ts
+++ b/lib/schema/flow.schema.ts
@@ -56,7 +56,7 @@ export const Decision = Type.Object({
   decision_node_position: Type.Optional(Type.Object({ x: Type.Number(), y: Type.Number() })), // Optional position for the decision node visualization
 });
 
-// FlowsFunctionSchema structure
+// Function definition (mapped to a pipecat-flows direct function on export)
 export const FlowFunction = Type.Object({
   name: Type.String({ minLength: 1 }),
   description: Type.String(),
@@ -64,6 +64,9 @@ export const FlowFunction = Type.Object({
   required: Type.Optional(Type.Array(Type.String())),
   next_node_id: Type.Optional(Type.String()), // Next node ID this function routes to (or default when decision exists)
   decision: Type.Optional(Decision), // Optional decision for conditional routing
+  // @flows_tool_options call options (omitted when left at their defaults)
+  cancel_on_interruption: Type.Optional(Type.Boolean()), // Cancel this call when the user interrupts (default: false)
+  timeout_secs: Type.Optional(Type.Number({ exclusiveMinimum: 0 })), // Per-tool timeout override in seconds (must be > 0)
 });
 
 // Pre/Post action structure
@@ -131,6 +134,9 @@ export const GlobalFunction = Type.Object({
   description: Type.String(),
   properties: Type.Optional(Type.Record(Type.String(), FunctionProperty)),
   required: Type.Optional(Type.Array(Type.String())),
+  // @flows_tool_options call options (omitted when left at their defaults)
+  cancel_on_interruption: Type.Optional(Type.Boolean()),
+  timeout_secs: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
 });
 
 export const FlowSchema = Type.Object({

--- a/lib/validation/validator.ts
+++ b/lib/validation/validator.ts
@@ -22,6 +22,18 @@ export function validateFlowJson(json: unknown): ValidationResult {
   return { valid: Boolean(isValid), errors: validateFlow.errors };
 }
 
+// Deterministic stringify (object keys sorted) so two structurally identical
+// definitions compare equal regardless of property order.
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(",")}}`;
+}
+
 export function customGraphChecks(flow: FlowJson): ErrorObject[] {
   const errors: ErrorObject[] = [];
   // Unique node ids
@@ -60,5 +72,34 @@ export function customGraphChecks(flow: FlowJson): ErrorObject[] {
       } as ErrorObject);
     }
   });
+
+  // Functions that share a name must share a definition. Code generation emits a
+  // single Python `async def` per name (the same function can legitimately be
+  // referenced from multiple nodes), so two same-named functions with differing
+  // definitions would silently drop the later one.
+  const fnSignatures = new Map<string, string>();
+  const checkFunction = (fn: unknown, instancePath: string) => {
+    const name = (fn as { name?: string })?.name;
+    if (!name) return;
+    const signature = stableStringify(fn);
+    const existing = fnSignatures.get(name);
+    if (existing === undefined) {
+      fnSignatures.set(name, signature);
+    } else if (existing !== signature) {
+      errors.push({
+        instancePath,
+        schemaPath: "#/uniqueFunctionName",
+        keyword: "uniqueFunctionName",
+        params: { name },
+        message: `Conflicting definitions for function "${name}": functions sharing a name must be identical`,
+      } as ErrorObject);
+    }
+  };
+  (flow.global_functions ?? []).forEach((fn, i) => checkFunction(fn, `/global_functions/${i}`));
+  flow.nodes.forEach((n) => {
+    const functions = (n.data?.functions as unknown[] | undefined) ?? [];
+    functions.forEach((fn, i) => checkFunction(fn, `/nodes/${n.id}/functions/${i}`));
+  });
+
   return errors;
 }

--- a/tests/codegen.test.ts
+++ b/tests/codegen.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+
+import { generatePythonCode } from "@/lib/codegen/pythonGenerator";
+import foodOrdering from "@/lib/examples/food_ordering.json";
+import type { FlowJson } from "@/lib/schema/flow.schema";
+
+const food = foodOrdering as unknown as FlowJson;
+
+describe("python code generation (pipecat-flows 1.3.0 direct functions)", () => {
+  const code = generatePythonCode(food);
+
+  it("imports only the modern flows surface", () => {
+    expect(code).toContain("from pipecat_flows import (");
+    expect(code).toContain("FlowManager");
+    expect(code).toContain("NodeConfig");
+    // Legacy/removed APIs must not be generated.
+    expect(code).not.toContain("FlowsFunctionSchema");
+    expect(code).not.toContain("FlowArgs");
+    expect(code).not.toContain("FlowResult");
+  });
+
+  it("emits direct functions with flow_manager first and typed params", () => {
+    expect(code).toContain(
+      "async def select_pizza_order(flow_manager: FlowManager, size: str, type: str) -> tuple[SelectPizzaOrderResult, NodeConfig]:"
+    );
+    // No handler indirection / arg extraction.
+    expect(code).not.toContain("handle_select_pizza_order");
+    expect(code).not.toContain('args.get("size"');
+  });
+
+  it("references functions directly in the node's functions list", () => {
+    expect(code).toContain("functions=[choose_pizza, choose_sushi]");
+    expect(code).toContain("functions=[select_pizza_order]");
+  });
+
+  it("routes to the next node via the returned NodeConfig", () => {
+    expect(code).toContain(
+      "return SelectPizzaOrderResult(size=size, type=type), create_confirm_node()"
+    );
+    // Transition-only function returns None as the result.
+    expect(code).toContain(
+      "async def choose_pizza(flow_manager: FlowManager) -> tuple[None, NodeConfig]:"
+    );
+    expect(code).toContain("return None, create_pizza_task_node()");
+  });
+
+  it("declares result types as plain TypedDicts", () => {
+    expect(code).toContain("from typing import TypedDict");
+    expect(code).toContain("class SelectPizzaOrderResult(TypedDict):");
+    expect(code).toContain("    size: str");
+  });
+
+  it("folds JSON-Schema enum constraints into the docstring Args section", () => {
+    expect(code).toContain("Args:");
+    expect(code).toContain('Allowed values: "small", "medium", "large".');
+  });
+
+  it("collapses role_messages into a single role_message string", () => {
+    expect(code).toContain("role_message=");
+    expect(code).not.toContain("role_messages=");
+  });
+
+  it("uses the modern worker-based FlowManager setup", () => {
+    expect(code).toContain("worker=worker,");
+    expect(code).toContain("await flow_manager.initialize(create_initial_node())");
+    expect(code).not.toContain("task=task");
+  });
+});
+
+describe("decision routing", () => {
+  const flowWithDecision: FlowJson = {
+    meta: { name: "Decision Flow", version: "0.1.0" },
+    nodes: [
+      {
+        id: "start",
+        type: "initial",
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Start",
+          task_messages: [{ role: "developer", content: "Ask for a number." }],
+          functions: [
+            {
+              name: "check_value",
+              description: "Check the provided value.",
+              properties: { value: { type: "integer", description: "The value." } },
+              required: ["value"],
+              decision: {
+                action: "result = value",
+                conditions: [{ operator: ">", value: "10", next_node_id: "big" }],
+                default_next_node_id: "small",
+              },
+            },
+          ],
+        },
+      },
+      {
+        id: "big",
+        type: "node",
+        position: { x: 1, y: 0 },
+        data: { label: "Big", task_messages: [{ role: "developer", content: "Big." }] },
+      },
+      {
+        id: "small",
+        type: "node",
+        position: { x: 2, y: 0 },
+        data: { label: "Small", task_messages: [{ role: "developer", content: "Small." }] },
+      },
+    ],
+    edges: [],
+  };
+
+  it("imports Any and emits if/elif/else branching", () => {
+    const code = generatePythonCode(flowWithDecision);
+    expect(code).toContain("from typing import Any");
+    expect(code).toContain(
+      "async def check_value(flow_manager: FlowManager, value: int) -> tuple[Any, NodeConfig]:"
+    );
+    expect(code).toContain("result = value");
+    expect(code).toContain("if result > 10:");
+    expect(code).toContain("return result, create_big_node()");
+    expect(code).toContain("return result, create_small_node()");
+  });
+});
+
+describe("global functions", () => {
+  const flowWithGlobal: FlowJson = {
+    meta: { name: "Global Flow", version: "0.1.0" },
+    global_functions: [
+      {
+        name: "get_estimate",
+        description: "Provide an estimate.",
+      },
+    ],
+    nodes: [
+      {
+        id: "start",
+        type: "initial",
+        position: { x: 0, y: 0 },
+        data: { label: "Start", task_messages: [{ role: "developer", content: "Hi." }] },
+      },
+    ],
+    edges: [],
+  };
+
+  it("emits global functions and references them in the setup", () => {
+    const code = generatePythonCode(flowWithGlobal);
+    expect(code).toContain("# Global functions (available at every node)");
+    expect(code).toContain(
+      "async def get_estimate(flow_manager: FlowManager) -> tuple[None, None]:"
+    );
+    expect(code).toContain("global_functions=[get_estimate],");
+  });
+});
+
+describe("@flows_tool_options call options", () => {
+  function flowWith(opts: { cancel_on_interruption?: boolean; timeout_secs?: number }): FlowJson {
+    return {
+      meta: { name: "Options Flow", version: "0.1.0" },
+      nodes: [
+        {
+          id: "start",
+          type: "initial",
+          position: { x: 0, y: 0 },
+          data: {
+            label: "Start",
+            task_messages: [{ role: "developer", content: "Hi." }],
+            functions: [{ name: "do_work", description: "Do some work.", ...opts }],
+          },
+        },
+      ],
+      edges: [],
+    };
+  }
+
+  it("emits no decorator and no import when options are default", () => {
+    const code = generatePythonCode(flowWith({}));
+    expect(code).not.toContain("flows_tool_options");
+  });
+
+  it("emits the decorator and import when cancel_on_interruption is set", () => {
+    const code = generatePythonCode(flowWith({ cancel_on_interruption: true }));
+    expect(code).toContain("    flows_tool_options,");
+    expect(code).toContain("@flows_tool_options(cancel_on_interruption=True)\nasync def do_work(");
+  });
+
+  it("emits timeout_secs and combines both options", () => {
+    const code = generatePythonCode(flowWith({ cancel_on_interruption: true, timeout_secs: 30 }));
+    expect(code).toContain(
+      "@flows_tool_options(cancel_on_interruption=True, timeout_secs=30)\nasync def do_work("
+    );
+  });
+
+  it("emits only timeout_secs when cancel_on_interruption is unset", () => {
+    const code = generatePythonCode(flowWith({ timeout_secs: 5 }));
+    expect(code).toContain("@flows_tool_options(timeout_secs=5)\nasync def do_work(");
+    expect(code).not.toContain("cancel_on_interruption");
+  });
+});
+
+describe("escaping and de-duplication", () => {
+  it("escapes triple quotes in a multi-line description so the docstring stays valid", () => {
+    const flow: FlowJson = {
+      meta: { name: "Quote Flow", version: "0.1.0" },
+      nodes: [
+        {
+          id: "start",
+          type: "initial",
+          position: { x: 0, y: 0 },
+          data: {
+            label: "Start",
+            task_messages: [{ role: "developer", content: "Hi." }],
+            functions: [
+              {
+                name: "do_work",
+                description: 'Wrap text in """triple quotes""".\nSecond line.',
+                properties: { value: { type: "string", description: 'Use """ here.' } },
+                required: ["value"],
+              },
+            ],
+          },
+        },
+      ],
+      edges: [],
+    };
+    const code = generatePythonCode(flow);
+    // The raw triple-quote sequence must be escaped, never left to close the docstring.
+    expect(code).not.toMatch(/[^\\]"""triple/);
+    expect(code).toContain('\\"\\"\\"triple');
+    expect(code).toContain('Use \\"\\"\\" here.');
+  });
+
+  it("does not redefine a global function that shares a node function's name", () => {
+    const flow: FlowJson = {
+      meta: { name: "Shared Name Flow", version: "0.1.0" },
+      global_functions: [{ name: "shared", description: "Global version." }],
+      nodes: [
+        {
+          id: "start",
+          type: "initial",
+          position: { x: 0, y: 0 },
+          data: {
+            label: "Start",
+            task_messages: [{ role: "developer", content: "Hi." }],
+            functions: [{ name: "shared", description: "Node version." }],
+          },
+        },
+      ],
+      edges: [],
+    };
+    const code = generatePythonCode(flow);
+    const defs = code.match(/^async def shared\(/gm) ?? [];
+    expect(defs.length).toBe(1);
+  });
+});

--- a/tests/codegen.test.ts
+++ b/tests/codegen.test.ts
@@ -251,4 +251,68 @@ describe("escaping and de-duplication", () => {
     const defs = code.match(/^async def shared\(/gm) ?? [];
     expect(defs.length).toBe(1);
   });
+
+  it("escapes backslashes so escape-like sequences stay valid Python", () => {
+    const flow: FlowJson = {
+      meta: { name: "Backslash Flow", version: "0.1.0" },
+      nodes: [
+        {
+          id: "start",
+          type: "initial",
+          position: { x: 0, y: 0 },
+          data: {
+            label: "Start",
+            task_messages: [{ role: "developer", content: "Hi." }],
+            functions: [{ name: "do_work", description: "Matches \\d+ and \\u escapes." }],
+          },
+        },
+      ],
+      edges: [],
+    };
+    const code = generatePythonCode(flow);
+    // Backslashes are doubled so e.g. \u can't form an invalid Python escape.
+    expect(code).toContain("Matches \\\\d+ and \\\\u escapes.");
+  });
+});
+
+describe("optional parameters honor the required list", () => {
+  const flow: FlowJson = {
+    meta: { name: "Optional Flow", version: "0.1.0" },
+    nodes: [
+      {
+        id: "start",
+        type: "initial",
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Start",
+          task_messages: [{ role: "developer", content: "Hi." }],
+          functions: [
+            {
+              name: "submit",
+              description: "Submit the form.",
+              properties: {
+                note: { type: "string", description: "An optional note." },
+                name: { type: "string", description: "The user's name." },
+              },
+              required: ["name"],
+            },
+          ],
+        },
+      },
+    ],
+    edges: [],
+  };
+
+  it("orders required params first and defaults optional ones to None", () => {
+    const code = generatePythonCode(flow);
+    expect(code).toContain(
+      "async def submit(flow_manager: FlowManager, name: str, note: str | None = None) -> tuple[SubmitResult, None]:"
+    );
+  });
+
+  it("marks optional fields nullable in the result TypedDict", () => {
+    const code = generatePythonCode(flow);
+    expect(code).toContain("    name: str\n");
+    expect(code).toContain("    note: str | None\n");
+  });
 });

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -20,4 +20,17 @@ describe("validator", () => {
     const custom = customGraphChecks(dup as FlowJson);
     expect(custom.some((e) => String(e.message).includes("Duplicate node id"))).toBe(true);
   });
+
+  it("accepts a positive function timeout_secs but rejects non-positive ones", () => {
+    const withTimeout = (secs: number) => {
+      const flow = JSON.parse(JSON.stringify(minimal));
+      flow.nodes[0].data.functions = [
+        { name: "do_work", description: "Do work.", timeout_secs: secs },
+      ];
+      return flow;
+    };
+    expect(validateFlowJson(withTimeout(30)).valid).toBe(true);
+    expect(validateFlowJson(withTimeout(0)).valid).toBe(false);
+    expect(validateFlowJson(withTimeout(-5)).valid).toBe(false);
+  });
 });

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -33,4 +33,41 @@ describe("validator", () => {
     expect(validateFlowJson(withTimeout(0)).valid).toBe(false);
     expect(validateFlowJson(withTimeout(-5)).valid).toBe(false);
   });
+
+  const flowWithFns = (a: object, b: object) =>
+    ({
+      meta: { name: "F", version: "0.1.0" },
+      nodes: [
+        {
+          id: "a",
+          type: "initial",
+          position: { x: 0, y: 0 },
+          data: { task_messages: [{ role: "developer", content: "x" }], functions: [a] },
+        },
+        {
+          id: "b",
+          type: "node",
+          position: { x: 1, y: 0 },
+          data: { task_messages: [{ role: "developer", content: "y" }], functions: [b] },
+        },
+      ],
+      edges: [],
+    }) as unknown as FlowJson;
+
+  it("flags same-name functions with conflicting definitions", () => {
+    const custom = customGraphChecks(
+      flowWithFns(
+        { name: "foo", description: "A", next_node_id: "b" },
+        { name: "foo", description: "B", next_node_id: "a" }
+      )
+    );
+    expect(custom.some((e) => e.keyword === "uniqueFunctionName")).toBe(true);
+  });
+
+  it("allows identical same-name functions across nodes (shared-function pattern)", () => {
+    const custom = customGraphChecks(
+      flowWithFns({ name: "foo", description: "A" }, { name: "foo", description: "A" })
+    );
+    expect(custom.some((e) => e.keyword === "uniqueFunctionName")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- Rewrites the Python export to generate **pipecat-flows 1.3.0 "direct functions"**: each function is an `async def name(flow_manager, ...)` whose schema is derived automatically from its type hints and docstring, replacing `FlowsFunctionSchema` + separate handlers. Results are plain `TypedDict`s (deprecated `FlowResult` dropped), `role_messages` collapse to a single `role_message` string, and the FlowManager scaffold uses the `worker=` API.
- Adds support for the **`@flows_tool_options`** decorator (`cancel_on_interruption`, `timeout_secs`): new optional function-schema fields, a "Call options" section in the function inspector with inline timeout validation (must be a number > 0), and codegen that emits the decorator + import only when an option is set.
- Updates `docs/INTEGRATION.md` and `docs/SCHEMA.md` to match.

JSON-Schema constraints (enum/min/max/pattern) are folded into the docstring `Args:` text since direct functions have no structured place for them. Triple quotes in user text are escaped so docstrings stay valid, and a node function never redefines a global function of the same name.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npx vitest run` — 24 passing (codegen + validator + adapters + storage + component)
- [x] Generated output for all example flows (plus decision, global, tool-options, and triple-quote cases) parses as valid Python via `ast.parse`
- [ ] Manual: open a flow in the editor, set a function's call options + timeout, confirm the "Show Code" panel emits `@flows_tool_options(...)` and that an invalid timeout shows the inline error
