### PR TITLE
Give each deployment its own asset URLs, so a stale stylesheet cannot be served

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,16 @@
-import type { NextConfig } from 'next';
+import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  // Turbopack names static chunks by module path, not content, so a chunk
+  // such as globals.css keeps its URL from one build to the next. Vercel
+  // serves those URLs from an immutable CDN cache, and a new deployment's
+  // HTML then loads the previous deployment's stylesheet. The deployment id
+  // becomes a query on every asset URL, so each deployment gets its own.
+  deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
   experimental: {
-    optimizePackageImports: [
-      '@xyflow/react'
-    ]
-  }
+    optimizePackageImports: ["@xyflow/react"],
+  },
 };
 
 export default nextConfig;
-


### PR DESCRIPTION
flows.pipecat.ai is serving the merged editor's HTML with the pre-merge stylesheet: the served CSS still has the shadcn defaults (`--radius: .625rem`, hex neutral tokens, `--sidebar-*`, `--chart-*`) and none of the new rules (`.crosshair-frame`, `.type-mono-label`, `--brand`, `--accent-line`, React Flow's styles), while the HTML carries the new class names. That is why the accent and the site styling are missing in production.

**Cause.** Turbopack in Next 16 names static chunks by module path, not content: appending a comment to `styles/globals.css` and rebuilding produces the same chunk filename. Vercel serves `/_next/static/immutable/...` from an immutable CDN cache, so a new deployment's HTML references the same URL as the last one and gets the old file.

**Fix.** `deploymentId: process.env.VERCEL_DEPLOYMENT_ID` in `next.config.ts`. Next then appends `?dpl=<deployment id>` to every asset URL, so each deployment loads its own chunks. Verified locally: a build with the variable set emits `/_next/static/chunks/<name>.css?dpl=<id>` for every stylesheet and script; without it, the bare URL as before.

Merging this triggers the deployment that repairs the site. Vercel's Skew Protection setting achieves the same by setting the id automatically; this keeps it explicit in the repo.